### PR TITLE
CI: Add GitHub Actions workflow for automated model run and pytest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,5 +48,7 @@ jobs:
     - name: Install Mesa and pytest
       run: pip install mesa pytest
     - name: Test with Pytest
-      run: pytest
-      # working-directory: boltzmann_wealth_model
+      run: |
+        export PYTHONPATH=$GITHUB_WORKSPACE
+        pytest
+      working-directory: boltzmann_wealth_model

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,11 @@ jobs:
           ${{ runner.os }}-python-cache-run-
     - name: Install Mesa
       run: pip install mesa
-    - name: Install Project
-      run: pip install -e .
     - name: Run model
-      run: python boltzmann_wealth_model/run.py
-      # working-directory: boltzmann_wealth_model
+      run: |
+        echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+        run.py
+      working-directory: boltzmann_wealth_model
 
   pytest:
     runs-on: ubuntu-latest
@@ -49,8 +49,8 @@ jobs:
           ${{ runner.os }}-python-cache-pytest-
     - name: Install Mesa and pytest
       run: pip install mesa pytest
-    - name: Install Project
-      run: pip install -e .
     - name: Test with Pytest
-      run: pytest
-      # working-directory: boltzmann_wealth_model
+      run: |
+        echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+        pytest
+      working-directory: boltzmann_wealth_model

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,17 +13,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.12"
-    - name: Get the current date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-    - name: Cache Python packages
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/pip
-          ~/.cache/pip/wheels
-        key: ${{ runner.os }}-python-cache-run-${{ steps.date.outputs.date }}
-        restore-keys: |
-          ${{ runner.os }}-python-cache-run-
     - name: Install Mesa
       run: pip install mesa
     - name: Run model
@@ -40,17 +29,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.12"
-    - name: Get the current date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-    - name: Cache Python packages
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/pip
-          ~/.cache/pip/wheels
-        key: ${{ runner.os }}-python-cache-pytest-${{ steps.date.outputs.date }}
-        restore-keys: |
-          ${{ runner.os }}-python-cache-pytest-
     - name: Install Mesa and pytest
       run: pip install mesa pytest
     - name: Test with Pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
           ${{ runner.os }}-python-cache-run-
     - name: Install Mesa
       run: pip install mesa
+    - name: Install Project
+      run: pip install -e .
     - name: Run model
       run: python boltzmann_wealth_model/run.py
       # working-directory: boltzmann_wealth_model
@@ -47,8 +49,8 @@ jobs:
           ${{ runner.os }}-python-cache-pytest-
     - name: Install Mesa and pytest
       run: pip install mesa pytest
+    - name: Install Project
+      run: pip install -e .
     - name: Test with Pytest
-      run: |
-        export PYTHONPATH=$GITHUB_WORKSPACE
-        pytest
-      working-directory: boltzmann_wealth_model
+      run: pytest
+      # working-directory: boltzmann_wealth_model

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,8 @@ jobs:
     - name: Install Mesa
       run: pip install mesa
     - name: Run model
-      run: python boltzmann_wealth_model/run.py
+      run: python run.py
+      working-directory: boltzmann_wealth_model
 
   pytest:
     runs-on: ubuntu-latest
@@ -26,7 +27,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.12"
-    - name: Install Mesa
-      run: pip install mesa
+    - name: Install Mesa and pytest
+      run: pip install mesa pytest
     - name: Test with Pytest
       run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Run model
       run: |
         echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-        run.py
+        python run.py
       working-directory: boltzmann_wealth_model
 
   pytest:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       run: pip install mesa
     - name: Run model
       run: |
-        echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+        export PYTHONPATH=$GITHUB_WORKSPACE
         python run.py
       working-directory: boltzmann_wealth_model
 
@@ -51,6 +51,6 @@ jobs:
       run: pip install mesa pytest
     - name: Test with Pytest
       run: |
-        echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+        export PYTHONPATH=$GITHUB_WORKSPACE
         pytest
       working-directory: boltzmann_wealth_model

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,15 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.12"
+    - name: Get the current date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+    - name: Cache Python packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-python-cache-run-${{ steps.date.outputs.date }}
+        restore-keys: |
+          ${{ runner.os }}-python-cache-run-
     - name: Install Mesa
       run: pip install mesa
     - name: Run model
@@ -27,6 +36,15 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.12"
+    - name: Get the current date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+    - name: Cache Python packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-python-cache-pytest-${{ steps.date.outputs.date }}
+        restore-keys: |
+          ${{ runner.os }}-python-cache-pytest-
     - name: Install Mesa and pytest
       run: pip install mesa pytest
     - name: Test with Pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,3 +31,4 @@ jobs:
       run: pip install mesa pytest
     - name: Test with Pytest
       run: pytest
+      working-directory: boltzmann_wealth_model

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,9 @@ jobs:
     - name: Cache Python packages
       uses: actions/cache@v3
       with:
-        path: ~/.cache/pip
+        path: |
+          ~/.cache/pip
+          ~/.cache/pip/wheels
         key: ${{ runner.os }}-python-cache-run-${{ steps.date.outputs.date }}
         restore-keys: |
           ${{ runner.os }}-python-cache-run-
@@ -43,7 +45,9 @@ jobs:
     - name: Cache Python packages
       uses: actions/cache@v3
       with:
-        path: ~/.cache/pip
+        path: |
+          ~/.cache/pip
+          ~/.cache/pip/wheels
         key: ${{ runner.os }}-python-cache-pytest-${{ steps.date.outputs.date }}
         restore-keys: |
           ${{ runner.os }}-python-cache-pytest-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.12"
-        cache: "pip"
     - name: Install Mesa
       run: pip install mesa
     - name: Run model
@@ -27,7 +26,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.12"
-        cache: "pip"
     - name: Install Mesa
       run: pip install mesa
     - name: Test with Pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
     - name: Install Mesa
       run: pip install mesa
     - name: Run model
-      run: python run.py
-      working-directory: boltzmann_wealth_model
+      run: python boltzmann_wealth_model/run.py
+      # working-directory: boltzmann_wealth_model
 
   pytest:
     runs-on: ubuntu-latest
@@ -31,4 +31,4 @@ jobs:
       run: pip install mesa pytest
     - name: Test with Pytest
       run: pytest
-      working-directory: boltzmann_wealth_model
+      # working-directory: boltzmann_wealth_model

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Build and Test
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  run-model:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+        cache: "pip"
+    - name: Install Mesa
+      run: pip install mesa
+    - name: Run model
+      run: python boltzmann_wealth_model/run.py
+
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+        cache: "pip"
+    - name: Install Mesa
+      run: pip install mesa
+    - name: Test with Pytest
+      run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,8 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Build and Test
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
+  # Initialize and run the model for a few steps just to see if it works (see run.py)
   run-model:
     runs-on: ubuntu-latest
     steps:
@@ -21,6 +19,7 @@ jobs:
         python run.py
       working-directory: boltzmann_wealth_model
 
+  # Run all the unittest with pytest
   pytest:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add GitHub Actions workflow for automated model run and pytest

- Introduces a new GitHub Actions workflow in `.github/workflows/test.yml`.
- The workflow includes two jobs: `run-model` and `pytest`.
- `run-model` initializes and runs the Boltzmann Wealth Model using Python 3.12 on Ubuntu to verify basic functionality.
- `pytest` job sets up the environment and runs unit tests using pytest for the Boltzmann Wealth Model.
- Both jobs install necessary dependencies, including Mesa, and set `PYTHONPATH` to the GitHub workspace.

Commit history is a bit messy, is left for transparency, but squash when merging.